### PR TITLE
chore: prepare for publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,42 @@
 # ExSzamlazzHu
 
-A very thing wrapper around Szamlazz.hu API.
+A very thin wrapper for the Szamlazz.hu API.
+
+---
+
+## Purpose
+
+The [Szamlazz.hu API](https://docs.szamlazz.hu) relies on `multipart/form-data` requests with an attached XML file, and the API's response is either `text/plain` or `application/xml`.
+
+This wrapper intends to abstract away the aforementioned aspects of the communication with the API by providing an interface which can be called with standard Elixir maps, and the result is also presented with an Elixir struct.
+
+```elixir
+{:ok, %ExSzamlazzHu.CreateInvoice.Result{} = result} = ExSzamlazzHu.create_invoice(params)
+```
+
+Even though the package provides its interface in English (i.e. with functions like `create_invoice`),
+but as a thin wrapper, the expected parameters follow the same shape as described in the [Szamlazz.hu API documentation](https://docs.szamlazz.hu/#xsd-scheme-compliance). This hopefully makes the adoption easier, as one would need to familiarize oneself with the service's own API anyway.
+
+## Features
+
+| Szamlazz.hu function     | Is it implemented? |
+| ------------------------ | :----------------: |
+| Create invoice           |         ✅         |
+| Reverse invoice          |         ❌         |
+| Register credit entry    |         ❌         |
+| Query invoice pdf        |         ❌         |
+| Query invoice xml        |         ❌         |
+| Delete pro forma invoice |         ❌         |
+| Create receipt           |         ❌         |
+| Reverse receipt          |         ❌         |
+| Query receipt            |         ❌         |
+| Send receipt             |         ❌         |
+| Query taxpayers          |         ❌         |
+| Create supplier account  |         ❌         |
 
 ## Installation
 
-If [available in Hex](https://hex.pm/docs/publish), the package can be installed
-by adding `ex_szamlazz_hu` to your list of dependencies in `mix.exs`:
+The package can be installed by adding `ex_szamlazz_hu` to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
@@ -15,6 +46,97 @@ def deps do
 end
 ```
 
-Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
-and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
-be found at <https://hexdocs.pm/ex_szamlazz_hu>.
+## Configuration
+
+**Szamlazz.hu**
+
+The authentication for Szamlazz.hu services are done using the so called "agent key" or the username/password pair.
+
+As Szamlazz.hu expects the credentials in the request payload, this package also works the same way. You will need to provide your credentials inside the request parameters.
+
+**Tesla**
+
+ExSzamlazzHu uses Tesla as a HTTP client. This means that you should configure Tesla to use the library your project is using. E.g. in your `config/config.exs`:
+
+```elixir
+config :tesla, :adapter, Tesla.Adapter.Hackney
+```
+
+See more in [the Tesla documentation](https://hexdocs.pm/tesla/readme.html#adapters).
+
+## Usage example
+
+To create an invoice via Szamlazz.hu, the parameters follow the same shape as described in the [Szamlazz.hu API documentation](https://docs.szamlazz.hu/#xsd-scheme-compliance).
+
+```elixir
+ExSzamlazzHu.create_invoice(%{
+    beallitasok: %{
+      szamlaagentkulcs: "your Szamlazz.hu agent key",
+      eszamla: true,
+      szamlaLetoltes: false,
+      valaszVerzio: 1,
+    },
+    fejlec: %{
+      teljesitesDatum: "2023-11-12",
+      fizetesiHataridoDatum: "2023-11-12",
+      fizmod: "Stripe",
+      penznem: "EUR",
+      szamlaNyelve: "en",
+      megjegyzes: "",
+      rendelesSzam: "Skynet-O129A22",
+      dijbekero: false,
+      fizetve: true
+    },
+    elado: %{},
+    vevo: %{
+      nev: "Sarah Connor",
+      orszag: "USA",
+      irsz: 32456,
+      telepules: "Los Angeles",
+      cim: "Engineering Drive",
+      email: "sarah.connor@no-skynet.com",
+      sendEmail: true
+    },
+    tetelek: [
+      %{
+        megnevezes: "T-101 disassembly kit",
+        mennyiseg: 2,
+        mennyisegiEgyseg: "db",
+        nettoEgysegar: 100,
+        afakulcs: 27,
+        nettoErtek: 200,
+        afaErtek: 54,
+        bruttoErtek: 254,
+      }
+    ]
+  })
+```
+
+The result of the call is a struct, which - among other things - contains the original response from the Szamlazz.hu API.
+
+```elixir
+{:ok, %ExSzamlazzHu.CreateInvoice.Result{}} = ExSzamlazzHu.create_invoice(params)
+
+%ExSzamlazzHu.CreateInvoice.Result{
+  success: true,                # Indicates whether the invoice was created
+  raw_response: nil,            # The raw response from the szamla.hu API
+  path_to_pdf_invoice: nil,     # The path to the created invoice, if the PDF file was requested
+  szlahu_id: nil,               # The (internal) ID of the created invoice
+  szlahu_szamlaszam: nil,       # The invoice number
+  szlahu_nettovegosszeg: nil,   # The net amount of the created invoice
+  szlahu_bruttovegosszeg: nil,  # The gross amount of the created invoice
+  szlahu_kintlevoseg: nil,      # The amount not yet paid
+  szlahu_vevoifiokurl: nil,     # The URL of the invoice
+  szlahu_error: nil,            # The error message, if any (and in Hungarian)
+  szlahu_error_code: nil,       # The error code
+  szlahu_down: false            # Indicates whether the Szamlazz.hu API is not available
+}
+```
+
+The properties with the `szlahu` prefix are not arbitrary, these are fields returned by the API.
+
+The `raw_response` contains the entire response of the API as a `%Tesla.Env{}` struct.
+
+If the `params.beallitasok.szamlaLetoltes` is `true`, then Szamlazz.hu's response will contain the invoice PDF. In this case, the wrapper will attempt to save the file locally (in the temp dir), and set the `path_to_pdf_invoice` to point to the saved file. You will still be able to access the file in the response via the `raw_response` property.
+
+If the call to Szamlazz.hu is successful, but Szamlazz.hu returns an error, the error will be described in `szlahu_error` (in Hungarian) and `szlahu_error_code` (as a string). To learn more about the error codes, check out the Szamlazz.hu API documentation [about error codes](https://docs.szamlazz.hu/#how-can-i-test-szamla-agent)

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,5 +1,3 @@
 import Config
 
-config :ex_szamlazz_hu, szamlazz_hu_api_url: "https://www.szamlazz.hu/szamla/"
-
-import_config "#{Mix.env()}.exs"
+config :tesla, :adapter, Tesla.Adapter.Hackney

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,3 +1,0 @@
-import Config
-
-config :tesla, :adapter, Tesla.Adapter.Hackney

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,3 +1,0 @@
-import Config
-
-config :tesla, :adapter, Tesla.Adapter.Hackney

--- a/lib/ex_szamlazz_hu.ex
+++ b/lib/ex_szamlazz_hu.ex
@@ -3,132 +3,48 @@ defmodule ExSzamlazzHu do
 
   @moduledoc """
   A very thin wrapper for the Szamlazz.hu API.
-
-  ## Installation
-
-      def deps do
-        [
-          {:ex_szamlazz_hu, "~> 0.1.0"}
-        ]
-      end
-
-  ExSzamlazzHu uses Tesla as a HTTP client. This means that you should configure Tesla to use the library your project is using. E.g. in your `config/config.exs`:application
-
-      config :tesla, :adapter, Tesla.Adapter.Hackney
-
-  See more at [Tesla](https://hexdocs.pm/tesla/readme.html#adapters).
-
-  ## Features
-
-  | Szamlazz.hu function     | Is implemented? |
-  | ------------------------- | --------------- |
-  | Create invoice           | ✅ |
-  | Reverse invoice          | ❌ |
-  | Register credit entry    | ❌ |
-  | Query invoice pdf        | ❌ |
-  | Query invoice xml        | ❌ |
-  | Delete pro forma invoice | ❌ |
-  | Create receipt           | ❌ |
-  | Reverse receipt          | ❌ |
-  | Query receipt            | ❌ |
-  | Send receipt             | ❌ |
-  | Query taxpayers          | ❌ |
-  | Create supplier account  | ❌ |
-
-  ## Usage
-
-  Even though this modules interface is in English (i.e. it provides functions like `create_invoice`),
-  but as a thin wrapper, the parameters follow the same shape as described in the [Szamlazz.hu API documentation](https://docs.szamlazz.hu/).
-
-  The result of the call is a struct, which - among other things - contains the original response from the Szamlazz.hu API.
-
-  For convenience, the result struct contains some other information, e.g.
-  - whether the call was successful or not
-  - the invoice identifier, if an invoice was created
-  - the path to the created invoice, if the PDF file download was requested
-  - and the error code, if an error occurred.
-
-  Read more at the given feature's documentation.
-  """
-
-  @doc """
-  Create invoice via Szamlazz.hu
-
-  The parameters follow the same shape as described in the [Szamlazz.hu API documentation](https://docs.szamlazz.hu/).
-
-    ExSzamlazzHu.create_invoice(%{
-        beallitasok: %{
-          szamlaagentkulcs: "your Szamlazz.hu agent key",
-          eszamla: true,
-          szamlaLetoltes: false,
-          valaszVerzio: 1,
-        },
-        fejlec: %{
-          teljesitesDatum: "2023-11-12",
-          fizetesiHataridoDatum: "2023-11-12",
-          fizmod: "Stripe",
-          penznem: "EUR",
-          szamlaNyelve: "en",
-          megjegyzes: "",
-          rendelesSzam: "Skynet-O129A22",
-          dijbekero: false,
-          fizetve: true
-        },
-        elado: %{},
-        vevo: %{
-          nev: "Sarah Connor",
-          orszag: "USA",
-          irsz: 32456,
-          telepules: "Los Angeles",
-          cim: "Engineering Drive",
-          email: "sarah.connor@no-skynet.com",
-          sendEmail: true
-        },
-        tetelek: [
-          %{
-            megnevezes: "T-800 disassembly kit",
-            mennyiseg: 2,
-            mennyisegiEgyseg: "db",
-            nettoEgysegar: 100,
-            afakulcs: 27,
-            nettoErtek: 200,
-            afaErtek: 54,
-            bruttoErtek: 254,
-          }
-        ]
-      })
-
-  The result of the call is a struct, which - among other things - contains the original response from the Szamlazz.hu API.
-
-      {:ok, %ExSzamlazzHu.CreateInvoice.Result{success: true}} = ExSzamlazzHu.create_invoice(params)
-
-      %ExSzamlazzHu.CreateInvoice.Result{
-        success: true,                # Indicates whether the request to the szamla.hu API was successful
-        raw_response: nil,            # The raw response from the szamla.hu API
-        szlahu_id: nil,               # The (internal) ID of the created invoice
-        szlahu_szamlaszam: nil,       # The invoice number
-        szlahu_nettovegosszeg: nil,   # The net amount of the created invoice
-        szlahu_bruttovegosszeg: nil,  # The gross amount of the created invoice
-        szlahu_kintlevoseg: nil,      # The amount not yet paid
-        szlahu_vevoifiokurl: nil,     # The URL of the invoice
-        path_to_pdf_invoice: nil,     # The path to the created invoice, if the PDF file was requested
-        szlahu_error: nil,            # The error message, if any (and in Hungarian)
-        szlahu_error_code: nil,       # The error code
-        szlahu_down: false            # Indicates whether the Szamlazz.hu API is not available
-      }
   """
   @moduledoc since: "0.1.0"
 
+  @doc """
+  Calls the Szamlazz.hu API [to create an invoice](https://docs.szamlazz.hu/#generating-invoices).
+
+  Returns `%ExSzamlazzHu.CreateInvoice.Result{}` struct when a call to the Szamlazz.hu API was made.
+  """
+  @doc since: "0.1.0"
+  @spec create_invoice(params :: map()) :: {:ok, CreateInvoice.Result.t()} | {:error, :cannot_save_temporary_file} | {:error, any()}
   def create_invoice(params), do: CreateInvoice.run(params)
+
+  @doc false
   def reverse_invoice(_params), do: {:error, :not_implemented}
+
+  @doc false
   def register_credit_entry(_params), do: {:error, :not_implemented}
+
+  @doc false
   def query_invoice_pdf(_params), do: {:error, :not_implemented}
+
+  @doc false
   def query_invoice_xml(_params), do: {:error, :not_implemented}
+
+  @doc false
   def delete_pro_forma_invoice(_params), do: {:error, :not_implemented}
+
+  @doc false
   def create_receipt(_params), do: {:error, :not_implemented}
+
+  @doc false
   def reverse_receipt(_params), do: {:error, :not_implemented}
+
+  @doc false
   def query_receipt(_params), do: {:error, :not_implemented}
+
+  @doc false
   def send_receipt(_params), do: {:error, :not_implemented}
+
+  @doc false
   def query_taxpayers(_params), do: {:error, :not_implemented}
+
+  @doc false
   def create_supplier_account(_params), do: {:error, :not_implemented}
 end

--- a/lib/modules/create_invoice.ex
+++ b/lib/modules/create_invoice.ex
@@ -6,6 +6,8 @@ defmodule ExSzamlazzHu.CreateInvoice do
   alias ExSzamlazzHu.CreateInvoice.Result
   alias ExSzamlazzHu.Utils.TemporaryFile
 
+  @url "https://www.szamlazz.hu/szamla/"
+
   @spec run(params :: map()) :: {:ok, Result.t()} | {:error, :cannot_save_temporary_file} | {:error, any()}
   def run(params) do
     with invoice_data <- InvoiceData.parse(params),
@@ -32,9 +34,7 @@ defmodule ExSzamlazzHu.CreateInvoice do
       |> Multipart.add_content_type_param("charset=utf-8")
       |> Multipart.add_file(file_path, name: "action-xmlagentxmlfile")
 
-    url = Application.get_env(:ex_szamlazz_hu, :szamlazz_hu_api_url)
-
-    Tesla.post(url, body)
+    Tesla.post(@url, body)
   end
 
   defp handle_response(%Tesla.Env{} = response, invoice_data) do

--- a/lib/modules/create_invoice/result.ex
+++ b/lib/modules/create_invoice/result.ex
@@ -1,8 +1,8 @@
 defmodule ExSzamlazzHu.CreateInvoice.Result do
   @moduledoc """
-  Represents the result of the invoice creation process.
+  Represents the result of the invoice creation call.
 
-  See the [documentation](https://hexdocs.pm/ex_szamlazz_hu/ExSzamlazzHu.html)
+  See the [documentation](https://hexdocs.pm/ex_szamlazz_hu)
   """
   @moduledoc since: "0.1.0"
 

--- a/mix.exs
+++ b/mix.exs
@@ -42,7 +42,7 @@ defmodule ExSzamlazzHu.MixProject do
 
   defp description do
     """
-    A very thing wrapper around Szamlazz.hu API.
+    A very thin wrapper for the Szamlazz.hu API.
     """
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -8,8 +8,7 @@ defmodule ExSzamlazzHu.MixProject do
     [
       app: :ex_szamlazz_hu,
       version: @version,
-      description: "Szamlazz.hu client",
-      name: "ExSzamlazzHu",
+      description: description(),
       source_url: @source_url,
       elixir: "~> 1.14",
       elixirc_paths: elixirc_paths(Mix.env()),
@@ -43,7 +42,7 @@ defmodule ExSzamlazzHu.MixProject do
 
   defp description do
     """
-    Szamlazz.hu client for Elixir
+    A very thing wrapper around Szamlazz.hu API.
     """
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -51,7 +51,6 @@ defmodule ExSzamlazzHu.MixProject do
 
   defp package do
     [
-      files: ["lib", "mix.exs", "README*", "LICENSE*"],
       maintainers: ["David Nagy", "Mikhail Alekseev"],
       licenses: ["MIT"],
       links: %{GitHub: @source_url},


### PR DESCRIPTION
In this PR I clean up and rearranged the documentation in anticipation of publishing the repo as a package to hex.pm.

I also messed around the `mix.exs` configurations for the same reason.

I removed the Szamlazz API url from the `config.exs` as the config file is never part of a package. And I put it into the CreateInvoice module. When a new module is added, a better place for it should be found too.