### PR TITLE
fix: fix error when not downloading a pdf

### DIFF
--- a/lib/modules/create_invoice.ex
+++ b/lib/modules/create_invoice.ex
@@ -91,6 +91,8 @@ defmodule ExSzamlazzHu.CreateInvoice do
     end
   end
 
+  defp maybe_add_invoice_path_info(info, _, _), do: info
+
   defp get_invoice_pdf_data(
          %Tesla.Env{} = response,
          %InvoiceData{beallitasok: %{szamlaLetoltes: true, valaszVerzio: 1}}

--- a/test/lib/modules/create_invoice_test.exs
+++ b/test/lib/modules/create_invoice_test.exs
@@ -51,6 +51,29 @@ defmodule ExSzamlazzHu.CreateInvoiceTest do
       assert result.szlahu_down == false
     end
 
+    test "should successfully create an invoice when the response type is text" do
+      params =
+        params([
+          {[:beallitasok, :valaszVerzio], 1},
+          {[:beallitasok, :szamlaLetoltes], false}
+        ])
+
+      assert {:ok, %CreateInvoice.Result{success: true} = result} = attempt_with_retry(params)
+
+      assert result.path_to_pdf_invoice == nil
+      assert %Tesla.Env{} = result.raw_response
+      assert result.raw_response.body != nil
+      assert result.szlahu_id != nil
+      assert result.szlahu_kintlevoseg == "0"
+      assert result.szlahu_nettovegosszeg == "200"
+      assert result.szlahu_bruttovegosszeg == "254"
+      assert result.szlahu_szamlaszam != nil
+      assert result.szlahu_vevoifiokurl != nil
+      assert result.szlahu_error == nil
+      assert result.szlahu_error_code == nil
+      assert result.szlahu_down == false
+    end
+
     test "should return the error code and error message when the agent key is missing" do
       params =
         params([


### PR DESCRIPTION
In this PR I fixed an error that occurs when the PDF invoice is not requested.

The `maybe_add_invoice_path_info` function was missing its default case overload. Also added a test case for this.