### PR TITLE
chore: refactor StructToXml module

### DIFF
--- a/lib/modules/create_invoice/customer.ex
+++ b/lib/modules/create_invoice/customer.ex
@@ -49,7 +49,7 @@ defmodule ExSzamlazzHu.CreateInvoice.Customer do
 
   def attrs(), do: nil
 
-  def content() do
+  def content(_) do
     [
       :nev,
       :orszag,

--- a/lib/modules/create_invoice/customer_ledger.ex
+++ b/lib/modules/create_invoice/customer_ledger.ex
@@ -25,7 +25,7 @@ defmodule ExSzamlazzHu.CreateInvoice.CustomerLedger do
 
   def attrs(), do: nil
 
-  def content() do
+  def content(_) do
     [
       :konyvelesDatum,
       :vevoAzonosito,

--- a/lib/modules/create_invoice/header.ex
+++ b/lib/modules/create_invoice/header.ex
@@ -52,7 +52,7 @@ defmodule ExSzamlazzHu.CreateInvoice.Header do
 
   def attrs(), do: nil
 
-  def content() do
+  def content(_) do
     [
       :keltDatum,
       :teljesitesDatum,

--- a/lib/modules/create_invoice/invoice_data.ex
+++ b/lib/modules/create_invoice/invoice_data.ex
@@ -41,7 +41,7 @@ defmodule ExSzamlazzHu.CreateInvoice.InvoiceData do
       "xsi:schemaLocation" => "http://www.szamlazz.hu/xmlszamla https://www.szamlazz.hu/szamla/docs/xsds/agent/xmlszamla.xsd"
     }
 
-  def content() do
+  def content(_) do
     [
       :beallitasok,
       :fejlec,

--- a/lib/modules/create_invoice/item.ex
+++ b/lib/modules/create_invoice/item.ex
@@ -44,7 +44,7 @@ defmodule ExSzamlazzHu.CreateInvoice.Items.Item do
 
   def attrs(), do: nil
 
-  def content() do
+  def content(_) do
     [
       :megnevezes,
       :azonosito,

--- a/lib/modules/create_invoice/item_ledger.ex
+++ b/lib/modules/create_invoice/item_ledger.ex
@@ -25,7 +25,7 @@ defmodule ExSzamlazzHu.CreateInvoice.Items.Item.ItemLedger do
 
   def attrs(), do: nil
 
-  def content() do
+  def content(_) do
     [
       :gazdasagiEsem,
       :gazdasagiEsemAfa,

--- a/lib/modules/create_invoice/items.ex
+++ b/lib/modules/create_invoice/items.ex
@@ -4,23 +4,26 @@ defmodule ExSzamlazzHu.CreateInvoice.Items do
   alias ExSzamlazzHu.CreateInvoice.Items.Item
   alias ExSzamlazzHu.Utils.StructToXML
 
-  defstruct []
+  defstruct [
+    :tetelek
+  ]
 
   def parse(nil), do: []
 
   def parse(params) do
-    Enum.map(params, &Item.parse/1)
+    items = Enum.map(params, &Item.parse/1)
+    Map.put(%__MODULE__{}, :tetelek, items)
   end
 
   def tag(), do: :tetelek
 
   def attrs(), do: nil
 
-  def content(items) do
-    items
+  def content(module = %__MODULE__{}) do
+    module.tetelek
   end
 
-  def to_xml(items) do
-    StructToXML.convert(%__MODULE__{}, tag(), attrs(), items)
+  def to_xml(module = %__MODULE__{}) do
+    StructToXML.convert(module)
   end
 end

--- a/lib/modules/create_invoice/mpl.ex
+++ b/lib/modules/create_invoice/mpl.ex
@@ -24,7 +24,7 @@ defmodule ExSzamlazzHu.CreateInvoice.Waybill.MPL do
 
   def attrs(), do: nil
 
-  def content() do
+  def content(_) do
     [
       :vevokod,
       :vonalkod,

--- a/lib/modules/create_invoice/ppp.ex
+++ b/lib/modules/create_invoice/ppp.ex
@@ -21,7 +21,7 @@ defmodule ExSzamlazzHu.CreateInvoice.Waybill.PPP do
 
   def attrs(), do: nil
 
-  def content() do
+  def content(_) do
     [
       :vonalkodPrefix,
       :vonalkodPostfix

--- a/lib/modules/create_invoice/seller.ex
+++ b/lib/modules/create_invoice/seller.ex
@@ -25,7 +25,7 @@ defmodule ExSzamlazzHu.CreateInvoice.Seller do
 
   def attrs(), do: nil
 
-  def content() do
+  def content(_) do
     [
       :bank,
       :bankszamlaszam,

--- a/lib/modules/create_invoice/settings.ex
+++ b/lib/modules/create_invoice/settings.ex
@@ -29,7 +29,7 @@ defmodule ExSzamlazzHu.CreateInvoice.Settings do
 
   def attrs(), do: nil
 
-  def content() do
+  def content(_) do
     [
       :felhasznalo,
       :jelszo,

--- a/lib/modules/create_invoice/sprinter.ex
+++ b/lib/modules/create_invoice/sprinter.ex
@@ -25,7 +25,7 @@ defmodule ExSzamlazzHu.CreateInvoice.Waybill.Sprinter do
 
   def attrs(), do: nil
 
-  def content() do
+  def content(_) do
     [
       :azonosito,
       :feladokod,

--- a/lib/modules/create_invoice/transoflex.ex
+++ b/lib/modules/create_invoice/transoflex.ex
@@ -25,7 +25,7 @@ defmodule ExSzamlazzHu.CreateInvoice.Waybill.Transoflex do
 
   def attrs(), do: nil
 
-  def content() do
+  def content(_) do
     [
       :azonosito,
       :shipmentID,

--- a/lib/modules/create_invoice/waybill.ex
+++ b/lib/modules/create_invoice/waybill.ex
@@ -36,7 +36,7 @@ defmodule ExSzamlazzHu.CreateInvoice.Waybill do
 
   def attrs(), do: nil
 
-  def content() do
+  def content(_) do
     [
       :uticel,
       :futarSzolgalat,

--- a/mix.exs
+++ b/mix.exs
@@ -37,7 +37,8 @@ defmodule ExSzamlazzHu.MixProject do
       {:ex_doc, "~> 0.29.4", only: :dev},
       {:credo, "~> 1.6", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.3", only: [:dev, :test], runtime: false},
-      {:faker, "~> 0.17", only: [:test]}
+      {:faker, "~> 0.17", only: [:test]},
+      {:mix_test_watch, "~> 1.1", only: [:dev, :test], runtime: false}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -17,6 +17,7 @@
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm", "69b09adddc4f74a40716ae54d140f93beb0fb8978d8636eaded0c31b6f099f16"},
   "mime": {:hex, :mime, "2.0.5", "dc34c8efd439abe6ae0343edbb8556f4d63f178594894720607772a041b04b02", [:mix], [], "hexpm", "da0d64a365c45bc9935cc5c8a7fc5e49a0e0f9932a761c55d6c52b142780a05c"},
   "mimerl": {:hex, :mimerl, "1.2.0", "67e2d3f571088d5cfd3e550c383094b47159f3eee8ffa08e64106cdf5e981be3", [:rebar3], [], "hexpm", "f278585650aa581986264638ebf698f8bb19df297f66ad91b18910dfc6e19323"},
+  "mix_test_watch": {:hex, :mix_test_watch, "1.1.1", "eee6fc570d77ad6851c7bc08de420a47fd1e449ef5ccfa6a77ef68b72e7e51ad", [:mix], [{:file_system, "~> 0.2.1 or ~> 0.3", [hex: :file_system, repo: "hexpm", optional: false]}], "hexpm", "f82262b54dee533467021723892e15c3267349849f1f737526523ecba4e6baae"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.3.1", "2c54013ecf170e249e9291ed0a62e5832f70a476c61da16f6aac6dca0189f2af", [:mix], [], "hexpm", "2682e3c0b2eb58d90c6375fc0cc30bc7be06f365bf72608804fb9cffa5e1b167"},
   "parse_trans": {:hex, :parse_trans, "3.4.1", "6e6aa8167cb44cc8f39441d05193be6e6f4e7c2946cb2759f015f8c56b76e5ff", [:rebar3], [], "hexpm", "620a406ce75dada827b82e453c19cf06776be266f5a67cff34e1ef2cbb60e49a"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.7", "354c321cf377240c7b8716899e182ce4890c5938111a1296add3ec74cf1715df", [:make, :mix, :rebar3], [], "hexpm", "fe4c190e8f37401d30167c8c405eda19469f34577987c76dde613e838bbc67f8"},

--- a/test/lib/modules/create_invoice/invoice_data_test.exs
+++ b/test/lib/modules/create_invoice/invoice_data_test.exs
@@ -7,6 +7,7 @@ defmodule ExSzamlazzHu.CreateInvoice.InvoiceDataTest do
   alias ExSzamlazzHu.CreateInvoice.Seller
   alias ExSzamlazzHu.CreateInvoice.Waybill
   alias ExSzamlazzHu.CreateInvoice.Waybill.MPL
+  alias ExSzamlazzHu.CreateInvoice.Items
   alias ExSzamlazzHu.CreateInvoice.Items.Item
   alias ExSzamlazzHu.Factories.InvoiceDataFactory
   alias ExSzamlazzHu.Factories.HeaderFactory
@@ -110,22 +111,24 @@ defmodule ExSzamlazzHu.CreateInvoice.InvoiceDataTest do
                      erteknyilvanitas: "value_statement"
                    }
                  },
-                 tetelek: [
-                   %Item{
-                     megnevezes: "name",
-                     azonosito: "identifier",
-                     mennyiseg: "1.5",
-                     mennyisegiEgyseg: "unit",
-                     nettoEgysegar: "net_unit_price",
-                     afakulcs: "27",
-                     arresAfaAlap: "margin_vat_base",
-                     nettoErtek: "100",
-                     afaErtek: "27",
-                     bruttoErtek: "127",
-                     megjegyzes: "comment",
-                     tetelFokonyv: nil
-                   }
-                 ]
+                 tetelek: %Items{
+                   tetelek: [
+                     %Item{
+                       megnevezes: "name",
+                       azonosito: "identifier",
+                       mennyiseg: "1.5",
+                       mennyisegiEgyseg: "unit",
+                       nettoEgysegar: "net_unit_price",
+                       afakulcs: "27",
+                       arresAfaAlap: "margin_vat_base",
+                       nettoErtek: "100",
+                       afaErtek: "27",
+                       bruttoErtek: "127",
+                       megjegyzes: "comment",
+                       tetelFokonyv: nil
+                     }
+                   ]
+                 }
                }
     end
   end

--- a/test/lib/modules/create_invoice/items_test.exs
+++ b/test/lib/modules/create_invoice/items_test.exs
@@ -7,22 +7,24 @@ defmodule ExSzamlazzHu.CreateInvoice.ItemsTest do
 
   describe "parse/1" do
     test "should parse a valid Item list" do
-      assert Items.parse(params()) == [
-               %Item{
-                 megnevezes: "name",
-                 azonosito: "identifier",
-                 mennyiseg: "1.5",
-                 mennyisegiEgyseg: "unit",
-                 nettoEgysegar: "net_unit_price",
-                 afakulcs: "27",
-                 arresAfaAlap: "margin_vat_base",
-                 nettoErtek: "100",
-                 afaErtek: "27",
-                 bruttoErtek: "127",
-                 megjegyzes: "comment",
-                 tetelFokonyv: nil
-               }
-             ]
+      assert Items.parse(params()) == %Items{
+               tetelek: [
+                 %Item{
+                   megnevezes: "name",
+                   azonosito: "identifier",
+                   mennyiseg: "1.5",
+                   mennyisegiEgyseg: "unit",
+                   nettoEgysegar: "net_unit_price",
+                   afakulcs: "27",
+                   arresAfaAlap: "margin_vat_base",
+                   nettoErtek: "100",
+                   afaErtek: "27",
+                   bruttoErtek: "127",
+                   megjegyzes: "comment",
+                   tetelFokonyv: nil
+                 }
+               ]
+             }
     end
 
     test "should parse an empty Item list" do


### PR DESCRIPTION
In this PR, I have refactored the StructToXML module to be more readable.

I have also refactored the `%Items{}` module to be a proper struct, holding the list of `%Item{}`s in a property. It felt like a mistake for a while to have made Items into a "dummy" struct that parses itself into a simple array of Item structs. Making it into a proper struct with a property holding the Item list, it became possible to simplify the converter logic too.