### PR TITLE
feat: unescape `szlahu_vevoifiokurl` value

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ The result of the call is a struct, which - among other things - contains the or
   szlahu_nettovegosszeg: nil,   # The net amount of the created invoice
   szlahu_bruttovegosszeg: nil,  # The gross amount of the created invoice
   szlahu_kintlevoseg: nil,      # The amount not yet paid
-  szlahu_vevoifiokurl: nil,     # The URL of the invoice
+  szlahu_vevoifiokurl: nil,     # The URL of the invoice - ExSzamlazzHu decodes the percent-escaped string sent by Szamlazz.hu
   szlahu_error: nil,            # The error message, if any (and in Hungarian)
   szlahu_error_code: nil,       # The error code
   szlahu_down: false            # Indicates whether the Szamlazz.hu API is not available

--- a/lib/modules/create_invoice.ex
+++ b/lib/modules/create_invoice.ex
@@ -61,13 +61,15 @@ defmodule ExSzamlazzHu.CreateInvoice do
   defp handle_success_response(%Tesla.Env{} = response, invoice_data) do
     header_map = Map.new(response.headers)
 
+    szlahu_vevoifiokurl = URI.decode(header_map["szlahu_vevoifiokurl"])
+
     params = %{
       szlahu_id: header_map["szlahu_id"],
       szlahu_nettovegosszeg: header_map["szlahu_nettovegosszeg"],
       szlahu_szamlaszam: header_map["szlahu_szamlaszam"],
       szlahu_bruttovegosszeg: header_map["szlahu_bruttovegosszeg"],
       szlahu_kintlevoseg: header_map["szlahu_kintlevoseg"],
-      szlahu_vevoifiokurl: header_map["szlahu_vevoifiokurl"]
+      szlahu_vevoifiokurl: szlahu_vevoifiokurl
     }
 
     result = maybe_add_invoice_path_info(params, response, invoice_data)

--- a/test/lib/modules/create_invoice_test.exs
+++ b/test/lib/modules/create_invoice_test.exs
@@ -26,6 +26,9 @@ defmodule ExSzamlazzHu.CreateInvoiceTest do
       assert result.szlahu_error == nil
       assert result.szlahu_error_code == nil
       assert result.szlahu_down == false
+
+      unescaped_szlahu_vevoifiokurl = URI.decode(result.szlahu_vevoifiokurl)
+      assert unescaped_szlahu_vevoifiokurl == result.szlahu_vevoifiokurl
     end
 
     test "should successfully create an invoice and save the invoice pdf locally when the response type is xml" do


### PR DESCRIPTION
In this PR, I added the utility of unescaping the invoice url received from Szamlazz.hu.

Szamlazz.hu sends the invoice url in the header in a percent-escaped string.
ExSzamlazzHu will decode it into a proper URI.